### PR TITLE
move weibull_min object initialization out of integrand, 3x speedup

### DIFF
--- a/examples/SIkR/model/sikr_model_v2.py
+++ b/examples/SIkR/model/sikr_model_v2.py
@@ -100,8 +100,9 @@ epsT = 0
 def incub(tau): #get probability that incubation time is lower than tau
     return lognorm.cdf(tau,incSdLog,0,math.exp(incMeanLog))
 
+WM=weibull_min(genWeibShape, 0, genWeibScale)
 def gener(tau): #probability density of generation time at tau
-    return R0*weibull_min(genWeibShape, 0, genWeibScale).pdf(tau)
+    return R0*WM.pdf(tau)
 
 def f(ht,htp): #Here we mean ht=\hat{\tau} and htp=\hat{\tau}' (p of prime)
     if (htp >= ht): #This just function f as defined above


### PR DESCRIPTION
Small optimization with large speed benefit. Apparently creating the weibull_min object is slow.
Identical results for one set of input parameters tested.